### PR TITLE
Pin envoy version to avoid deprecation errors

### DIFF
--- a/envoy/envoy.Dockerfile
+++ b/envoy/envoy.Dockerfile
@@ -1,3 +1,3 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy:v1.10.0
 COPY ./envoy.yaml /etc/envoy/envoy.yaml
 CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml


### PR DESCRIPTION
Pin envoy version to avoid deprecation errors

I know this is not a production repo, but I thought this could help other people avoid errors when trying out to build shielded light wallets