### PR TITLE
a few fixes to make this current

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ file for an Envoy proxy that listens on `localhost:8081` and will route requests
 
 See [the `lightwalletd` documentation](https://github.com/zcash-hackworks/lightwalletd)
 for details on how to set up a local `lightwalletd` testnet instance. Note that when
-starting the frontend, you may need to use `--bind-addr 0.0.0.0:9067` so that the Docker
+starting the frontend, you may need to use `--grpc-bind-addr 0.0.0.0:9067` so that the Docker
 container can access it.
 
 To build and run the Envoy proxy:
 
 ```sh
 $ docker build -t lightwalletd/envoy -f envoy/envoy.Dockerfile envoy
-$ docker run -d -p 8081:8081 --network=host lightwalletd/envoy
+$ docker run -d --network=host lightwalletd/envoy
 ```
 
 ## Running the demo

--- a/envoy/envoy.Dockerfile
+++ b/envoy/envoy.Dockerfile
@@ -1,3 +1,3 @@
-FROM envoyproxy/envoy:v1.10.0
+FROM envoyproxy/envoy:v1.14.1
 COPY ./envoy.yaml /etc/envoy/envoy.yaml
 CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml

--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -25,13 +25,12 @@ static_resources:
                   cluster: lightwalletd_frontend
                   max_grpc_timeout: 0s
               cors:
-                allow_origin:
-                - "*"
+                allow_origin_string_match:
+                - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
-                enabled: true
           http_filters:
           - name: envoy.grpc_web
           - name: envoy.cors


### PR DESCRIPTION
@str4d this is a straightforward fix to deprecated logic.

Four things that have staled:
1. `envoyproxy/envoy:latest` is no longer a dockerhub tagged image
2. `lightwalletd` has a different flag from that mentioned in the README
3. The CORS interface of `envoy` has changed.
4. It is now deprecated to use both "-p" and `network="host"` in docker run invocations.